### PR TITLE
Change "-var x=y" to "-var" "x=y"

### DIFF
--- a/packer.py
+++ b/packer.py
@@ -182,7 +182,8 @@ class Packer(object):
         elif self.only:
             self._add_opt('-only={0}'.format(self._join_comma(self.only)))
         for var, value in self.vars.items():
-            self._add_opt("-var '{0}={1}'".format(var, value))
+            self._add_opt("-var")
+            self._add_opt("{0}={1}".format(var, value))
         if self.var_file:
             self._add_opt('-var-file={0}'.format(self.var_file))
 


### PR DESCRIPTION
Just a small change ... otherwise `-var 'x=y'` gets passed as one argument, and results in the following error: `flag provided but not defined: -var 'x`

Regards.