### PR TITLE
for python3, ensure that packer inspect output is plain text

### DIFF
--- a/packer.py
+++ b/packer.py
@@ -115,7 +115,8 @@ class Packer(object):
 
         result = self.packer_cmd()
         if mrf:
-            result.parsed_output = self._parse_inspection_output(result.stdout)
+            result.parsed_output = self._parse_inspection_output(
+                result.stdout.decode('utf-8'))
         else:
             result.parsed_output = None
         return result


### PR DESCRIPTION
Allows `packer.inspect(mrf=True)` to work without raising an exception in Python 3. Tested under Python 2 as well.