### PR TITLE
Remove installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The interface has been developed vs. Packer v0.7.5.
 
 ## Installation
 
-You must have Packer installed prior to using this client though as installer class is provided to install packer for you.
+You must have Packer installed prior to using this client.
 
 ```shell
  pip install python-packer
@@ -151,19 +151,6 @@ p.validate(syntax_only=False)
 
 p = packer.Packer(packerfile, ...)
 print(p.version())
-```
-
-### PackerInstaller.install()
-
-This installs packer to `packer_path` using the `installer_path` and verifies that the installation was successful.
-
-```python
-
-packer_path = '/usr/bin/'
-installer_path = 'Downloads/packer_0.7.5_linux_amd64.zip'
-
-p = packer.Installer(packer_path, installer_path)
-p.install()
 ```
 
 ## Shell Interaction

--- a/packer.py
+++ b/packer.py
@@ -1,7 +1,8 @@
-import sh
-import os
 import json
+import os
 import zipfile
+
+import sh
 
 DEFAULT_PACKER_PATH = 'packer'
 
@@ -10,8 +11,14 @@ class Packer(object):
     """A packer client
     """
 
-    def __init__(self, packerfile, exc=None, only=None, vars=None,
-                 var_file=None, exec_path=DEFAULT_PACKER_PATH, out_iter=None,
+    def __init__(self,
+                 packerfile,
+                 exc=None,
+                 only=None,
+                 vars=None,
+                 var_file=None,
+                 exec_path=DEFAULT_PACKER_PATH,
+                 out_iter=None,
                  err_iter=None):
         """
         :param string packerfile: Path to Packer template file
@@ -24,8 +31,8 @@ class Packer(object):
         self.packerfile = self._validate_argtype(packerfile, str)
         self.var_file = var_file
         if not os.path.isfile(self.packerfile):
-            raise OSError('packerfile not found at path: {0}'.format(
-                self.packerfile))
+            raise OSError(
+                'packerfile not found at path: {0}'.format(self.packerfile))
         self.exc = self._validate_argtype(exc or [], list)
         self.only = self._validate_argtype(only or [], list)
         self.vars = self._validate_argtype(vars or {}, dict)
@@ -41,7 +48,10 @@ class Packer(object):
         self.packer = sh.Command(exec_path)
         self.packer = self.packer.bake(**kwargs)
 
-    def build(self, parallel=True, debug=False, force=False,
+    def build(self,
+              parallel=True,
+              debug=False,
+              force=False,
               machine_readable=False):
         """Executes a `packer build`
 
@@ -115,7 +125,7 @@ class Packer(object):
         result = self.packer_cmd()
         if mrf:
             result.parsed_output = self._parse_inspection_output(
-                                                        result.stdout.decode())
+                result.stdout.decode())
         else:
             result.parsed_output = None
         return result
@@ -176,8 +186,8 @@ class Packer(object):
 
     def _validate_argtype(self, arg, argtype):
         if not isinstance(arg, argtype):
-            raise PackerException('{0} argument must be of type {1}'.format(
-                arg, argtype))
+            raise PackerException(
+                '{0} argument must be of type {1}'.format(arg, argtype))
         return arg
 
     def _append_base_arguments(self):

--- a/packer.py
+++ b/packer.py
@@ -227,28 +227,6 @@ class Packer(object):
         return parts
 
 
-class Installer(object):
-    def __init__(self, packer_path, installer_path):
-        self.packer_path = packer_path
-        self.installer_path = installer_path
-
-    def install(self):
-        with open(self.installer_path, 'rb') as f:
-            zip = zipfile.ZipFile(f)
-            for path in zip.namelist():
-                zip.extract(path, self.packer_path)
-        exec_path = os.path.join(self.packer_path, 'packer')
-        if not self._verify_packer_installed(exec_path):
-            raise PackerException('packer installation failed. '
-                                  'Executable could not be found under: '
-                                  '{0}'.format(exec_path))
-        else:
-            return exec_path
-
-    def _verify_packer_installed(self, packer_path):
-        return os.path.isfile(packer_path)
-
-
 class ValidationObject():
     pass
 


### PR DESCRIPTION
There is a discussion (#10) around removing this feature. I agree that this is probably not needed, as there are other ways to get packer installed.

I thought I'd put this together to satisfy that discussion.